### PR TITLE
feat: replace pattern in url path value

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-fetch/api.mustache
@@ -100,7 +100,7 @@ export const {{classname}}FetchParamCreator = function (configuration?: Configur
     {{/required}}
     {{/allParams}}
             const localVarPath = `{{{path}}}`{{#pathParams}}
-                .replace(`{${"{{baseName}}"}}`, encodeURIComponent(String({{paramName}}))){{/pathParams}};
+                .replace(`\{${"{{baseName}}"}(=[a-zA-Z0-9]+\/\*(\/versions\/\*)?)?\}`, String({{paramName}})){{/pathParams}};
             const localVarUrlObj = url.parse(localVarPath, true);
             const localVarRequestOptions = Object.assign({ method: '{{httpMethod}}' }, options);
             const localVarHeaderParameter = {} as any;


### PR DESCRIPTION
The PR introduces the following changes:

- if the URL contains URL path parameter with pattern (i.e. `/v1alpha/services/documentAI/{name=documentSets/*/versions/*}`), the patter is replaced as well.
- the following scenarios are handled (`*` is a literal character, not a wildcard):
  - no pattern
  - <collection_name>/*
  - <collection_name/*/versions/*
- replaced value is no longer URL-encoded
