### PR TITLE
feat(go): replace pattern in url path value, fix constant names.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 {{#imports}}	"{{import}}"
 {{/imports}}
@@ -49,7 +50,8 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "{{{path}}}"{{#pathParams}}
-	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", fmt.Sprintf("%v", {{paramName}}), -1){{/pathParams}}
+	{{=<% %>=}}re := regexp.MustCompile(`{[a-zA-Z0-9]+=(projects/\*(/[a-zA-Z0-9]+/[a-zA-Z0-9]+/\*(/versions/\*)?)?)?}`)<%={{ }}=%>
+	localVarPath = re.ReplaceAllString(localVarPath, fmt.Sprintf("%v", {{paramName}})){{/pathParams}}
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/modules/swagger-codegen/src/main/resources/go/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/model.mustache
@@ -11,7 +11,7 @@ type {{{classname}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{
 const (
 	{{#allowableValues}}
 	{{#enumVars}}
-	{{name}} {{{classname}}} = {{{value}}}
+	{{{classname}}}_{{name}} {{{classname}}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}


### PR DESCRIPTION
This is the Go equivalent of https://github.com/h2oai/swagger-codegen/pull/1. Also fixes the naming of the constants (which tends to cause conflicts). The problem was that the proto value of `ARTIFACT_STATUS_UNSPECIFIED` was translated to a constant named `UNSPECIFIED`. `BASE_MODEL_UNSPECIFIED` was translated to `UNSPECIFIED` which caused conflict.