### PR TITLE
fix: needed for newer versions of swagger-protoc gen, now all modified langs are in sync.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -50,7 +50,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "{{{path}}}"{{#pathParams}}
-	{{=<% %>=}}re := regexp.MustCompile(`{[a-zA-Z0-9]+=(projects/\*(/[a-zA-Z0-9]+/[a-zA-Z0-9]+/\*(/versions/\*)?)?)?}`)<%={{ }}=%>
+	{{=<% %>=}}re := regexp.MustCompile(`{[a-zA-Z0-9]+(=projects/\*(/[a-zA-Z0-9]+/[a-zA-Z0-9]+/\*(/versions/\*)?)?)?}`)<%={{ }}=%>
 	localVarPath = re.ReplaceAllString(localVarPath, fmt.Sprintf("%v", {{paramName}})){{/pathParams}}
 
 	localVarHeaderParams := make(map[string]string)


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

